### PR TITLE
add a sorter with highlighter to multi-ripgrep

### DIFF
--- a/lua/custom/telescope/multi-ripgrep.lua
+++ b/lua/custom/telescope/multi-ripgrep.lua
@@ -2,6 +2,7 @@ local conf = require("telescope.config").values
 local finders = require "telescope.finders"
 local make_entry = require "telescope.make_entry"
 local pickers = require "telescope.pickers"
+local sorters = require "telescope.sorters"
 
 local flatten = vim.tbl_flatten
 
@@ -58,13 +59,24 @@ return function(opts)
     cwd = opts.cwd,
   }
 
+  local sorter = sorters.Sorter:new {
+    scoring_function = function()
+      return 1
+    end,
+    highlighter = function(_, prompt, display)
+      local fzy = opts.fzy_mod or require "telescope.algos.fzy"
+      local pieces = vim.split(prompt, "  ")
+      return fzy.positions(pieces[1], display)
+    end,
+  }
+
   pickers
     .new(opts, {
       debounce = 100,
       prompt_title = "Live Grep (with shortcuts)",
       finder = custom_grep,
       previewer = conf.grep_previewer(opts),
-      sorter = require("telescope.sorters").empty(),
+      sorter = sorter,
     })
     :find()
 end


### PR DESCRIPTION
Heya! 🤸🏼‍♂️

I really enjoyed your Advanced Telescope video, and have been playing along to add the "MultiGrep" to my setup.

I wanted to replace entirely my use of `live_grep`, but I noticed that the "MultiGrep" was missing highlighting of the match in the picker section.

`live_grep` uses `require("telescope.sorters").highlighter_only(opts)` as its sorter, and that did the trick, except when using a filename filtering pattern.

See: https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/builtin/__files.lua

So I copied the code from `highlighter_only` and adapted it to work with a split prompt.

See: https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/sorters.lua

Before:
<img width="2032" alt="image" src="https://github.com/user-attachments/assets/915ec7b2-85b7-4a61-a910-3e76b83b71c8" />
After:
<img width="2032" alt="image" src="https://github.com/user-attachments/assets/e595b2e7-9bdc-4ac4-b676-4e6380d69aab" />

I hope you find this useful, keep up the great work!

Étienne

Video: https://www.youtube.com/watch?v=xdXE1tOT-qg 